### PR TITLE
Improved usage of filesystem layers

### DIFF
--- a/php71/Dockerfile
+++ b/php71/Dockerfile
@@ -2,8 +2,8 @@ FROM php:7.1
 
 LABEL maintainer="tim.spiekerkoetter@hdnet.de"
 
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
-RUN apt-get update
-RUN apt-get install -y unzip rsync nodejs git ssh
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
+    apt-get update && \
+    apt-get install -y unzip rsync nodejs git ssh && \
+    curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
+    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Zumindest _apt-get update_ und _apt-get install [...]_ sollten immer zusammen stehen, da ein _install_ in einem separaten Layer dazu führen kann, dass veraltete Paketlisten verwendet werden. :)