### PR TITLE
Add PHP 7.4 image with Node LTS and npm LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,5 @@ Directory | Image
 `/php73` | hdnet/typo3-build:php7.3
 `/php74` | hdnet/typo3-build:php7.4
 `/php74-node-lts` | hdnet/typo3-build:php7.4-node-lts
+`/php81-node-lts` | hdnet/typo3-build:php8.1-node-lts
+

--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@ Directory | Image
 `/php71` | hdnet/typo3-build:php7.1
 `/php73` | hdnet/typo3-build:php7.3
 `/php74` | hdnet/typo3-build:php7.4
+`/php74-node-lts` | hdnet/typo3-build:php7.4-node-lts

--- a/php74-node-lts/Dockerfile
+++ b/php74-node-lts/Dockerfile
@@ -1,0 +1,14 @@
+FROM php:7.4-cli
+
+LABEL maintainer="tim.spiekerkoetter@hdnet.de, thomas.cieslar@hdnet.de"
+
+RUN curl -sL https://deb.nodesource.com/setup_lts.x | bash - && \
+    apt-get update && \
+    apt-get install -y unzip rsync nodejs git ssh libfreetype6-dev libjpeg62-turbo-dev libpng-dev libgmp-dev libzip-dev && \
+    npm i -g npm@lts && \
+    docker-php-ext-configure gd --with-freetype --with-jpeg && \
+    docker-php-ext-install -j$(nproc) gd gmp zip mysqli && \
+    curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /var/www

--- a/php81-node-lts/Dockerfile
+++ b/php81-node-lts/Dockerfile
@@ -1,0 +1,14 @@
+FROM php:8.1-cli
+
+LABEL maintainer="tim.spiekerkoetter@hdnet.de, thomas.cieslar@hdnet.de"
+
+RUN curl -sL https://deb.nodesource.com/setup_lts.x | bash - && \
+    apt-get update && \
+    apt-get install -y unzip rsync nodejs git ssh libfreetype6-dev libjpeg62-turbo-dev libpng-dev libgmp-dev libzip-dev && \
+    npm i -g npm@8 && \
+    docker-php-ext-configure gd --with-freetype --with-jpeg && \
+    docker-php-ext-install -j$(nproc) gd gmp zip mysqli && \
+    curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /var/www


### PR DESCRIPTION
Basically, this is the PHP 7.4 image, except that the latest LTS of Node.js and npm are always installed here.